### PR TITLE
Figures in Matlab 2016a are not anymore handles, but objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ variablescmaes.mat
 *.zip
 *.gz
 exp/experiments/*/
-exp/pproc/generated scripts
+exp/pproc/generated_scripts
 exp/pproc/scripts/html/
 exp/pproc/scripts/tmp/
 exp/pproc/compAlgMat.mat*

--- a/exp/pproc/catEvalSet.m
+++ b/exp/pproc/catEvalSet.m
@@ -64,12 +64,12 @@ function [evals, settings] = catEvalSet(folders, funcSet)
   % concatenate evaluations from different experiments and with the same
   % settings
   exp_evals_ne = cat(3, exp_evals_ne{:});
-  nSettings = length(settings);
+  nSettings = length(settings_ne);
   evals = cell(length(funcSet.BBfunc), length(funcSet.dims), nSettings);
-  for s = 1 : nSettings    
+  for s = 1 : nSettings
     for f = 1 : length(funcSet.BBfunc)
       for d = 1 : length(funcSet.dims)
-        if notEmptySet(s)
+        if ~isempty(settings_ne{s})
           evals{f, d, s} = [exp_evals_ne{f, d, settingsID == s}];
         else
           evals{f, d, s} = exp_evals{s}{f, d};

--- a/exp/pproc/generateReport.m
+++ b/exp/pproc/generateReport.m
@@ -26,7 +26,7 @@ function generateReport(expFolder, varargin)
   end
   
   % parse input
-  reportSettings = settings2struct(varargin);
+  reportSettings = settings2struct(varargin{:});
   publishOption = defopts(reportSettings, 'Publish', 'off');
   reportDescription = defopts(reportSettings, 'Description', []);
   if ~iscell(expFolder)

--- a/exp/pproc/generateReport.m
+++ b/exp/pproc/generateReport.m
@@ -85,7 +85,7 @@ function generateReport(expFolder, varargin)
     reportName = [expName{1}, '_report.m'];
   end
   % report folder for all generated scripts
-  defPpFolder = fullfile('exp', 'pproc', 'generated scripts');
+  defPpFolder = fullfile('exp', 'pproc', 'generated_scripts');
   if ~isdir(defPpFolder)
     mkdir(defPpFolder)
   end

--- a/exp/pproc/relativeFValuesPlot.m
+++ b/exp/pproc/relativeFValuesPlot.m
@@ -257,11 +257,11 @@ function handle = relativePlot(data_stats, settings)
     
     % legend settings
     if strcmp(settings.legendOption, 'out')
-      handle = zeros(1, nPlots + 1);
+      handle = cell(1, nPlots + 1);
       legendFigNum = nPlots + 1;
       settings.legendLocation = 'EastOutside';
     else
-      handle = zeros(1, nPlots);
+      handle = cell(1, nPlots);
       legendFigNum = 1;
     end
     
@@ -269,7 +269,7 @@ function handle = relativePlot(data_stats, settings)
     plottedInAny = false(1, numOfData);
     for f = 1:nFunsToPlot
       for d = 1:nDimsToPlot
-        handle((d-1) * nFunsToPlot + f) = ...
+        handle{(d-1) * nFunsToPlot + f} = ...
           figure('Units', 'centimeters', 'Position', [1, 1, 12.5, 6]);
         plottedInAny = plottedInAny | ...
           onePlot(relativeData, f, d, settings, dispLegend && (strcmp(settings.legendOption, 'show') || (f*d == legendFigNum)), ...
@@ -277,7 +277,7 @@ function handle = relativePlot(data_stats, settings)
       end
     end
     if strcmp(settings.legendOption, 'out')
-      handle(legendFigNum) = soloLegend(settings.colors(plottedInAny, :), settings.datanames(plottedInAny), 2);
+      handle{legendFigNum} = soloLegend(settings.colors(plottedInAny, :), settings.datanames(plottedInAny), 2);
     end
   end
   


### PR DESCRIPTION
Matlab has changed behaviour of Figures, see
http://uk.mathworks.com/help/matlab/graphics_transition/graphics-handles-are-now-objects-not-doubles.html

and one more bugfix in varargin
